### PR TITLE
Modified composer.json to retain PHP 5.6.x compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
     "name": "icomefromthenet/reverse-regex",
     "description": "Convert Regular Expressions into text, for testing",
-    "keywords": ["regex","testing","test data","generator"],
+    "keywords": [
+        "regex",
+        "testing",
+        "test data",
+        "generator"
+    ],
     "homepage": "http://github.com/icomefromthenet/ReverseRegex",
     "type": "library",
     "license": "MIT",
@@ -13,16 +18,17 @@
         }
     ],
     "require-dev": {
-       "phpunit/phpunit": "~4.3"
+        "phpunit/phpunit": "~4.3"
     },
     "require": {
-        "doctrine/common"      : "~2.3",
-        "patchwork/utf8"       : ">=1.3"
+        "php": "^5.6",
+        "doctrine/common": "~2.7.3",
+        "patchwork/utf8": ">=1.3"
     },
     "autoload": {
         "psr-0": {
             "ReverseRegex": "src/",
-            "PHPStats"    : "src/"
+            "PHPStats": "src/"
         }
     }
 }

--- a/src/ReverseRegex/Random/SimpleRandom.php
+++ b/src/ReverseRegex/Random/SimpleRandom.php
@@ -37,7 +37,8 @@ class SimpleRandom implements GeneratorInterface
     public function __construct($seed = null)
     {
         if ($seed === null || $seed === 0) {
-            $this->seed(mt_rand());
+            ## 6 - Propagate the call to mt_rand() by assigning it to $seed
+            $seed = mt_rand();
         }
         
         $this->seed($seed);


### PR DESCRIPTION
**Problem:** `"doctrine/common": "~2.3"` will cause the latest 2.x version to be pulled in (currently 2.9). From 2.8 onwards, doctrine/common requires PHP7. This means your `v0.0.6.3` tag is broken on PHP 5.6.x.

**Solution:** This pull request updates the composer file to `"doctrine/common": "~2.7.3"` (notice the addition of `.3` on the end) so it will never go beyond the 2.7.x doctrine/common code base. I've also included `"php": "^5.6"` to ensure this branch cannot be run on PHP 7.x by accident.

I request that you please create a new branch, `v0.0.6.x` or `compat-php5.6.x` etc, at your tag `v0.0.6.3` and merge this pull request onto that. This will allow everyone to continue using your library on PHP 5.6.x. It will also introduce a new tag `v0.0.6.4`.