### PR TITLE
Add class name instead of namespace alias in extend construction

### DIFF
--- a/src/ReverseRegex/Lexer.php
+++ b/src/ReverseRegex/Lexer.php
@@ -10,7 +10,7 @@ use ReverseRegex\Exception as LexerException;
   *  @author Lewis Dyer <getintouch@icomefromthenet.com>
   *  @since 0.0.1
   */
-class Lexer extends BaseLexer
+class Lexer extends BaseLexer\AbstractLexer
 {
 
     //  ----------------------------------------------------------------------------


### PR DESCRIPTION
Issue:
After installing this lib as a dependency if Symfony 5.2.6 I have met an error after creating an instance of `ReverseRegex\Lexer` in my service.
```
Attempted to load class "Lexer" from namespace "Doctrine\Common".
Did you forget a "use" statement for e.g. "Twig\Lexer", "Symfony\Component\ExpressionLanguage\Lexer", "PhpParser\Lexer" or "Doctrine\ORM\Query\Lexer"?

```

Solution:
Replace extended class name  `class Lexer extends BaseLexer` with `class Lexer extends BaseLexer\AbstractLexer` in file `src/ReverseRegex/Lexer.php` 

